### PR TITLE
Exit stack parsing loop in a different way

### DIFF
--- a/Source/Engine/Agent/HookEngineStackTrace.cpp
+++ b/Source/Engine/Agent/HookEngineStackTrace.cpp
@@ -86,6 +86,8 @@ VOID CNktDvHookEngine::GetStackTrace(__out SIZE_T *lpnOutput, __in SIZE_T nCount
         lpnOutput[k] = CheckHookedEntry((SIZE_T)lpdwFrame[1], lpInUseStack);
         //NKT_ASSERT((lpnOutput[k] & 0xFFFF) != 0x010E); //<<== CAN LEAD INTO FALSE POSITIVES
         //try to read byte at lpnOutput[k], if that "eip" is invalid, an exception will raise and loop will end
+        if (lpnOutput[k] == 0)
+          break;
         temp8 = *((LPBYTE)lpnOutput[k]);
         k++;
         nCount--;


### PR DESCRIPTION
Previous exit by exception on null pointer exception is working,
but causing multiple exception messages in debug output.